### PR TITLE
Updated the plugin from npe1 to npe2

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |
-          git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
 
       # note: if you need dependencies from conda, considering using

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2
@@ -33,14 +33,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # these libraries, along with pytest-xvfb (added in the `deps` in tox.ini),
-      # enable testing on Qt on linux
-      - name: Install Linux libraries
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
-            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
+      # these libraries enable testing on Qt on linux
+      - uses: tlambert03/setup-qt-libs@v1
 
       # strategy borrowed from vispy for installing opengl libs on windows
       - name: Install Windows OpenGL
@@ -60,12 +54,14 @@ jobs:
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        run: tox
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
@@ -90,5 +86,5 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
         run: |
           git tag
-          python setup.py sdist bdist_wheel
+          python -m build .
           twine upload dist/*

--- a/napari_itk_io/__init__.py
+++ b/napari_itk_io/__init__.py
@@ -4,4 +4,4 @@ except ImportError:
     __version__ = "unknown"
 
 from ._reader import napari_get_reader
-from ._writer import napari_get_writer, napari_write_image
+from ._writer import write_single, write_multiple

--- a/napari_itk_io/_reader.py
+++ b/napari_itk_io/_reader.py
@@ -3,12 +3,10 @@ This module provides itk-based file reading functionality in a reader plugin for
 
 """
 from pathlib import Path
-import numpy as np
 import itk
 from itk_napari_conversion import image_layer_from_image
-from napari_plugin_engine import napari_hook_implementation
 
-@napari_hook_implementation
+
 def napari_get_reader(path):
     """An itk implementation of the napari_get_reader hook specification.
 

--- a/napari_itk_io/_writer.py
+++ b/napari_itk_io/_writer.py
@@ -1,20 +1,22 @@
 """
-This module is an example of a barebones writer plugin for napari
-
-It implements the ``napari_get_writer`` and ``napari_write_image`` hook specifications.
-see: https://napari.org/docs/dev/plugins/hook_specifications.html
-
-Replace code below according to your needs
+This module is an example of a barebones writer plugin for napari.
+It implements the Writer specification.
+see: https://napari.org/plugins/stable/guides.html#writers
+Replace code below according to your needs.
 """
+from __future__ import annotations
+from typing import TYPE_CHECKING, List, Any, Sequence, Tuple, Union
 
-from napari_plugin_engine import napari_hook_implementation
+if TYPE_CHECKING:
+    DataType = Union[Any, Sequence[Any]]
+    FullLayerData = Tuple[DataType, dict, str]
 
 
-@napari_hook_implementation
-def napari_get_writer():
+def write_single(path: str, data: Any, meta: dict):
+    """Writes a single layer"""
     pass
 
 
-@napari_hook_implementation
-def napari_write_image():
+def write_multiple(path: str, data: List[FullLayerData]):
+    """Writes multiple layers of different types."""
     pass

--- a/napari_itk_io/napari.yaml
+++ b/napari_itk_io/napari.yaml
@@ -1,0 +1,25 @@
+name: napari-itk-io
+display_name: napari-itk-io
+schema_version: 0.1.0
+contributions:
+  commands:
+  - id: napari-itk-io.get_reader
+    title: Read files using the ITK IO
+    python_name: napari_itk_io._reader:napari_get_reader
+  - id: napari-itk-io.write_multiple
+    title: Save multiple layers with the ITK IO (not implemented yet)
+    python_name: napari_itk_io._writer:write_multiple
+  - id: napari-itk-io.write_single
+    title: Save single layer with the ITK IO (not implemented yet)
+    python_name: napari_itk_io._writer:write_single
+  readers:
+  - command: napari-itk-io.get_reader
+    filename_patterns: ['*']
+    accepts_directories: true
+  writers:
+  - command: napari-itk-io.write_multiple
+    layer_types: ['image*', 'labels*']
+    filename_extensions: ['.nii']
+  - command: napari-itk-io.write_single
+    layer_types: [ 'image*', 'labels*' ]
+    filename_extensions: ['.nii']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-napari-plugin-engine>=0.1.4
+napari-plugin-engine>=0.2.0
 itk-io>=5.2.0
 itk-napari-conversion
 numpy

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,9 @@ setup(
         'License :: OSI Approved :: Apache Software License',
     ],
     entry_points={
-        'napari.plugin': [
-            'napari-itk-io = napari_itk_io',
+        "napari.manifest": [
+            "napari-itk-io = napari_itk_io:napari.yaml",
         ],
     },
+    package_data={"napari_itk_io": ["napari.yaml"]},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -39,4 +39,4 @@ deps =
     itk-io
     itk-napari-conversion
     numpy
-commands = pytest -v --color=yes --cov={{cookiecutter.module_name}} --cov-report=xml
+commands = pytest -v --color=yes --cov=napari-itk-io --cov-report=xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38,39}-{linux,macos,windows}
+envlist = py{38,39,310}-{linux,macos,windows}
+isolated_build=true
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
     
 [gh-actions:env]
 PLATFORM =
@@ -31,8 +32,11 @@ deps =
     pytest-xvfb ; sys_platform == 'linux'
     # you can remove these if you don't use them
     napari
-    magicgui
     pytest-qt
     qtpy
     pyqt5
-commands = pytest -v --color=yes --cov=napari_itk_io --cov-report=xml
+    napari-plugin-engine
+    itk-io
+    itk-napari-conversion
+    numpy
+commands = pytest -v --color=yes --cov={{cookiecutter.module_name}} --cov-report=xml

--- a/tox.ini
+++ b/tox.ini
@@ -39,4 +39,4 @@ deps =
     itk-io
     itk-napari-conversion
     numpy
-commands = pytest -v --color=yes --cov=napari-itk-io --cov-report=xml
+commands = pytest -v --color=yes --cov=napari_itk_io --cov-report=xml


### PR DESCRIPTION
As the plugin had some issues with the newest napari version (0.4.14) I updated it to the new napari plugin engine 2.
Now everything works fine again and the plugin is ready for future napari releases.