### PR TITLE
ENH: Add image writer

### DIFF
--- a/src/napari_itk_io/_tests/test_writer.py
+++ b/src/napari_itk_io/_tests/test_writer.py
@@ -1,7 +1,35 @@
-# from napari_itk_io import write_single_image, write_multiple
+from napari_itk_io import write_multiple #, write_single
+import numpy as np
+import itk
 
-# add your tests here...
+def test_write_single_image(tmp_path):
+    # write fake data
+    original_data = np.random.rand(20, 20)
+    original_metadata = {'name': 'test_layer', 'metadata': {}}
+    filepath = str(tmp_path / "test_file.nii")
+    written_filepaths = write_multiple(filepath, [(original_data, original_metadata, 'image')])
+    assert filepath == written_filepaths[0]
+
+    # read it back
+    image = itk.imread(filepath)
+    np.testing.assert_allclose(original_data, image)
 
 
-def test_something():
-    pass
+def test_write_multiple_images(tmp_path):
+    # write fake data
+    original_data = (np.random.rand(20, 20), np.random.rand(20, 20))
+    original_metadata = ({'name': 'test_layer1', 'metadata': {}},
+                        {'name': 'test_layer2', 'metadata': {}})
+    filepath = str(tmp_path / "test_file.nii")
+    written_filepaths = write_multiple(filepath, [(original_data[0], original_metadata[0], 'image'),
+                                                  (original_data[1], original_metadata[1], 'image')])
+    assert(len(written_filepaths) == 2)
+
+    # read them back
+    for i, written_filepath in enumerate(written_filepaths):
+        assert original_metadata[i]['name'] in written_filepath 
+        image = itk.imread(written_filepath)
+        np.testing.assert_allclose(original_data[i], image)
+
+
+

--- a/src/napari_itk_io/_writer.py
+++ b/src/napari_itk_io/_writer.py
@@ -9,16 +9,35 @@ Replace code below according to your needs.
 from __future__ import annotations
 from typing import TYPE_CHECKING, List, Any, Sequence, Tuple, Union
 
+import itk
+from itk_napari_conversion import image_from_image_layer
+from pathlib import Path
+import napari
+
 if TYPE_CHECKING:
     DataType = Union[Any, Sequence[Any]]
     FullLayerData = Tuple[DataType, dict, str]
 
 
-def write_single(path: str, data: Any, meta: dict):
+def write_single(path: str, data: Any, meta: dict) -> List[str]:
     """Writes a single layer"""
     pass
 
 
-def write_multiple(path: str, data: List[FullLayerData]):
+def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
     """Writes multiple layers of different types."""
-    pass
+    written_paths = []
+    for i, image_layer_tuple in enumerate(data):
+        image_layer = napari.layers.Image(image_layer_tuple[0], metadata=image_layer_tuple[1]['metadata'])
+        image = image_from_image_layer(image_layer)
+
+        if len(data) == 1:
+            itk.imwrite(image, path)
+            written_paths = [path]
+        else:
+            unique_path = Path(path)
+            unique_path = str(Path(unique_path.parent) / (unique_path.stem + "_" + image_layer_tuple[1]['name'] + unique_path.suffix))
+            itk.imwrite(image, unique_path)
+            written_paths.append(unique_path)
+
+    return written_paths  


### PR DESCRIPTION
Aims to fix https://github.com/InsightSoftwareConsortium/napari-itk-io/issues/7. It will also be helpful for the elastix-napari plugin to write the result image from the registration (https://github.com/SuperElastix/elastix_napari/tree/main).

It is pretty barebones right now. @thewtex any ideas what else should be added? Should it support writing dicoms?